### PR TITLE
Fix "Resource Not Found" status code and add task deletion by id

### DIFF
--- a/src/main/java/dev/artemfedorov/eventplanner/event/task/TaskRestController.java
+++ b/src/main/java/dev/artemfedorov/eventplanner/event/task/TaskRestController.java
@@ -48,4 +48,15 @@ public class TaskRestController {
     ) {
         return ResponseEntity.ok(taskService.findTaskByEventIdAndTaskId(eventId, taskId));
     }
+
+    @DeleteMapping("/{taskId}")
+    public ResponseEntity<?> handleDeleteEventTaskById(
+            @PathVariable Integer eventId,
+            @PathVariable Integer taskId
+    ) {
+        taskService.deleteTaskByEventIdAndTaskId(eventId, taskId);
+
+        return ResponseEntity.noContent()
+                .build();
+    }
 }

--- a/src/main/java/dev/artemfedorov/eventplanner/event/task/TaskService.java
+++ b/src/main/java/dev/artemfedorov/eventplanner/event/task/TaskService.java
@@ -32,4 +32,13 @@ public class TaskService {
         return taskRepository.findByEventIdAndId(eventId, taskId)
                 .orElseThrow(() -> new TaskNotFoundException(eventId, taskId));
     }
+
+    public void deleteTaskByEventIdAndTaskId(Integer eventId, Integer taskId) {
+        eventRepository.findById(eventId)
+                .orElseThrow(() -> new EventNotFoundException(eventId));
+        taskRepository.findById(taskId)
+                .orElseThrow(() -> new TaskNotFoundException(eventId, taskId));
+
+        taskRepository.deleteById(taskId);
+    }
 }

--- a/src/main/java/dev/artemfedorov/eventplanner/exceptionhandler/RestControllerExceptionHandler.java
+++ b/src/main/java/dev/artemfedorov/eventplanner/exceptionhandler/RestControllerExceptionHandler.java
@@ -18,12 +18,12 @@ public class RestControllerExceptionHandler {
 
     @ExceptionHandler(EventNotFoundException.class)
     public ResponseEntity<String> handleEventNotFoundException(EventNotFoundException exception) {
-        return new ResponseEntity<>(exception.getMessage(), new HttpHeaders(), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(exception.getMessage(), new HttpHeaders(), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(TaskNotFoundException.class)
     public ResponseEntity<String> handleTaskNotFoundException(TaskNotFoundException exception) {
-        return new ResponseEntity<>(exception.getMessage(), new HttpHeaders(), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(exception.getMessage(), new HttpHeaders(), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/test/java/dev/artemfedorov/eventplanner/event/EventRestControllerIT.java
+++ b/src/test/java/dev/artemfedorov/eventplanner/event/EventRestControllerIT.java
@@ -132,7 +132,7 @@ class EventRestControllerIT {
 
         mockMvc.perform(requestBuilder)
                 .andExpectAll(
-                        status().isBadRequest(),
+                        status().isNotFound(),
                         content().contentType(new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8)),
                         content().string("Could not find event with id: " + id)
                 );

--- a/src/test/java/dev/artemfedorov/eventplanner/event/task/TaskRestControllerIT.java
+++ b/src/test/java/dev/artemfedorov/eventplanner/event/task/TaskRestControllerIT.java
@@ -16,8 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.Matchers.hasSize;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Sql("/sql/event/task/task_rest_controller/test_data.sql")
@@ -32,6 +32,9 @@ class TaskRestControllerIT {
 
     @Autowired
     EventRepository eventRepository;
+
+    @Autowired
+    private TaskRepository taskRepository;
 
     @Test
     void handleAddTaskToEventById_EventWithGivenIdExists_ReturnsValidResponseEntity() throws Exception {
@@ -95,7 +98,7 @@ class TaskRestControllerIT {
 
         mockMvc.perform(requestBuilder)
                 .andExpectAll(
-                        status().isBadRequest(),
+                        status().isNotFound(),
                         content().contentType(new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8)),
                         content().string("Could not find event with id: " + eventId)
                 );
@@ -140,7 +143,7 @@ class TaskRestControllerIT {
 
         mockMvc.perform(requestBuilder)
                 .andExpectAll(
-                        status().isBadRequest(),
+                        status().isNotFound(),
                         content().contentType(new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8)),
                         content().string("Could not find event with id: " + eventId)
                 );
@@ -170,7 +173,7 @@ class TaskRestControllerIT {
 
         mockMvc.perform(requestBuilder)
                 .andExpectAll(
-                        status().isBadRequest(),
+                        status().isNotFound(),
                         content().contentType(new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8)),
                         content().string("Task with id " + taskId + " for event " + eventId + " not found")
                 );
@@ -185,7 +188,53 @@ class TaskRestControllerIT {
 
         mockMvc.perform(requestBuilder)
                 .andExpectAll(
-                        status().isBadRequest(),
+                        status().isNotFound(),
+                        content().contentType(new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8)),
+                        content().string("Could not find event with id: " + eventId)
+                );
+    }
+
+    @Test
+    void handleDeleteEventTaskById_EventWithGivenIdHasTaskWithGivenId_ReturnsValidResponseEntity() throws Exception {
+        Integer eventId = 1;
+        Integer taskId = 1;
+
+        var requestBuilder = delete("/api/events/{eventId}/tasks/{taskId}", eventId, taskId);
+
+        mockMvc.perform(requestBuilder)
+                .andExpectAll(
+                        status().isNoContent(),
+                        jsonPath("$").doesNotExist()
+                );
+
+        assertTrue(taskRepository.findById(taskId).isEmpty());
+    }
+
+    @Test
+    void handleDeleteEventTaskById_EventWithGivenIdDoesNotHaveTaskWithGivenId_ReturnsValidResponseEntity() throws Exception {
+        Integer eventId = 1;
+        Integer taskId = 10;
+
+        var requestBuilder = delete("/api/events/{eventId}/tasks/{taskId}", eventId, taskId);
+
+        mockMvc.perform(requestBuilder)
+                .andExpectAll(
+                        status().isNotFound(),
+                        content().contentType(new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8)),
+                        content().string("Task with id " + taskId + " for event " + eventId + " not found")
+                );
+    }
+
+    @Test
+    void handleDeleteEventTaskById_EventWithGivenIdDoesNotExist_ReturnsValidResponseEntity() throws Exception {
+        Integer eventId = 100;
+        Integer taskId = 1;
+
+        var requestBuilder = delete("/api/events/{eventId}/tasks/{taskId}", eventId, taskId);
+
+        mockMvc.perform(requestBuilder)
+                .andExpectAll(
+                        status().isNotFound(),
                         content().contentType(new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8)),
                         content().string("Could not find event with id: " + eventId)
                 );


### PR DESCRIPTION
This PR introduces the following changes:

Fix for "Resource Not Found" error status code:
The status code for `EventNotFoundException` and `TaskNotFoundException` has been changed from 400 to 404 to comply with standard HTTP status codes for missing resources.

Feature: task deletion by id:
Added the ability to delete task events using both the task id and event id.