### PR TITLE
Fix enum fields (status, category) in Task to store as varchar and add prePersist method

### DIFF
--- a/src/main/java/dev/artemfedorov/eventplanner/event/task/Task.java
+++ b/src/main/java/dev/artemfedorov/eventplanner/event/task/Task.java
@@ -41,6 +41,7 @@ public class Task {
     private String note;
 
     @Column(name = "c_category")
+    @Enumerated(EnumType.STRING)
     private Category category;
 
     @Column(name = "c_date")
@@ -48,10 +49,22 @@ public class Task {
     private LocalDateTime date;
 
     @Column(name = "c_status")
+    @Enumerated(EnumType.STRING)
     private TaskStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_event")
     @JsonIgnore
     private Event event;
+
+    @PreUpdate
+    @PrePersist
+    public void prePersist() {
+        if (category == null) {
+            category = Category.NOT_SPECIFIED;
+        }
+        if (status == null) {
+            status = TaskStatus.TO_DO;
+        }
+    }
 }

--- a/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1__initial_schema.sql
@@ -9,12 +9,12 @@ create table t_event
 create table t_task
 (
     id         serial primary key,
-    c_name     varchar not null CHECK ( char_length(c_name) >= 1),
+    c_name     varchar                         not null CHECK ( char_length(c_name) >= 1),
     c_note     varchar,
-    c_category varchar,
+    c_category varchar default 'NOT_SPECIFIED' not null,
     c_date     timestamp,
-    c_status   varchar,
-    id_event   int     not null,
+    c_status   varchar default 'TO_DO'         not null,
+    id_event   int                             not null,
     constraint fk__t_task__t_event
         foreign key (id_event)
             references t_event (id)


### PR DESCRIPTION
### Problem:
The status and category fields in the Task model were previously stored as int in the database, which led to confusion around the values and caused issues with supporting future values.

### What was done:
Specified an enumerated type for the `status` and `category` fields as string for better readability and flexibility.
Added `NOT NULL` constraints and default values for the status and category columns in the database.
Implemented a `@PrePersist`/`@PreUpdate` method in the Task class to initialize these fields with default values before saving, ensuring compliance with the `NOT NULL` constraint.

### Why it matters:
These changes improve data clarity and align the data types with what is expected for enum fields.
The database schema updates with `NOT NULL` and default values increase reliability and prevent errors when saving data.