### PR TITLE
Refactor task deletion and implement PATCH endpoint for task editing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     </scm>
     <properties>
         <java.version>21</java.version>
+        <commons-beanutils.version>1.9.4</commons-beanutils.version>
     </properties>
     <dependencies>
         <dependency>
@@ -69,6 +70,12 @@
             <artifactId>flyway-database-postgresql</artifactId>
             <version>10.20.1</version>
         </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>${commons-beanutils.version}</version>
+        </dependency>
+
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/dev/artemfedorov/eventplanner/config/Config.java
+++ b/src/main/java/dev/artemfedorov/eventplanner/config/Config.java
@@ -1,0 +1,13 @@
+package dev.artemfedorov.eventplanner.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class Config {
+
+    @Bean
+    public IgnoreNullBeanUtilsBean ignoreNullBeanUtilsBean() {
+        return new IgnoreNullBeanUtilsBean();
+    }
+}

--- a/src/main/java/dev/artemfedorov/eventplanner/config/IgnoreNullBeanUtilsBean.java
+++ b/src/main/java/dev/artemfedorov/eventplanner/config/IgnoreNullBeanUtilsBean.java
@@ -1,0 +1,15 @@
+package dev.artemfedorov.eventplanner.config;
+
+import org.apache.commons.beanutils.BeanUtilsBean;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class IgnoreNullBeanUtilsBean extends BeanUtilsBean {
+
+    @Override
+    public void copyProperty(Object dest, String name, Object value) throws IllegalAccessException, InvocationTargetException {
+        if (value != null) {
+            super.copyProperty(dest, name, value);
+        }
+    }
+}

--- a/src/main/java/dev/artemfedorov/eventplanner/event/task/TaskRestController.java
+++ b/src/main/java/dev/artemfedorov/eventplanner/event/task/TaskRestController.java
@@ -1,13 +1,16 @@
 package dev.artemfedorov.eventplanner.event.task;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.artemfedorov.eventplanner.event.EventService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/events/{eventId}/tasks")
@@ -17,9 +20,12 @@ public class TaskRestController {
 
     private final EventService eventService;
 
-    public TaskRestController(TaskService taskService, EventService eventService) {
+    private final ObjectMapper objectMapper;
+
+    public TaskRestController(TaskService taskService, EventService eventService, ObjectMapper objectMapper) {
         this.taskService = taskService;
         this.eventService = eventService;
+        this.objectMapper = objectMapper;
     }
 
     @PostMapping
@@ -55,6 +61,19 @@ public class TaskRestController {
             @PathVariable Integer taskId
     ) {
         taskService.deleteTaskByEventIdAndTaskId(eventId, taskId);
+
+        return ResponseEntity.noContent()
+                .build();
+    }
+
+    @PatchMapping(path = "/{taskId}")
+    public ResponseEntity<?> handleEditTask(
+            @PathVariable Integer eventId,
+            @PathVariable Integer taskId,
+            @RequestBody Map<String, Object> patch
+    ) throws InvocationTargetException, IllegalAccessException {
+        Task patchTask = objectMapper.convertValue(patch, Task.class);
+        taskService.editTaskByEventIdAndTaskId(patchTask, eventId, taskId);
 
         return ResponseEntity.noContent()
                 .build();

--- a/src/main/java/dev/artemfedorov/eventplanner/event/task/TaskService.java
+++ b/src/main/java/dev/artemfedorov/eventplanner/event/task/TaskService.java
@@ -1,9 +1,12 @@
 package dev.artemfedorov.eventplanner.event.task;
 
+import dev.artemfedorov.eventplanner.config.IgnoreNullBeanUtilsBean;
 import dev.artemfedorov.eventplanner.event.Event;
 import dev.artemfedorov.eventplanner.event.EventNotFoundException;
 import dev.artemfedorov.eventplanner.event.EventRepository;
 import org.springframework.stereotype.Service;
+
+import java.lang.reflect.InvocationTargetException;
 
 @Service
 public class TaskService {
@@ -12,9 +15,12 @@ public class TaskService {
 
     private final EventRepository eventRepository;
 
-    public TaskService(TaskRepository taskRepository, EventRepository eventRepository) {
+    private final IgnoreNullBeanUtilsBean utilsBean;
+
+    public TaskService(TaskRepository taskRepository, EventRepository eventRepository, IgnoreNullBeanUtilsBean utilsBean) {
         this.taskRepository = taskRepository;
         this.eventRepository = eventRepository;
+        this.utilsBean = utilsBean;
     }
 
     public Task addTaskToEventById(Task task, Integer eventId) {
@@ -36,9 +42,28 @@ public class TaskService {
     public void deleteTaskByEventIdAndTaskId(Integer eventId, Integer taskId) {
         eventRepository.findById(eventId)
                 .orElseThrow(() -> new EventNotFoundException(eventId));
-        taskRepository.findById(taskId)
+        taskRepository.findByEventIdAndId(eventId, taskId)
                 .orElseThrow(() -> new TaskNotFoundException(eventId, taskId));
 
         taskRepository.deleteById(taskId);
+    }
+
+    public void editTaskByEventIdAndTaskId(
+            Task patchTask,
+            Integer eventId,
+            Integer taskId
+    ) throws InvocationTargetException, IllegalAccessException {
+        eventRepository.findById(eventId)
+                .orElseThrow(() -> new EventNotFoundException(eventId));
+        Task task = taskRepository.findByEventIdAndId(eventId, taskId)
+                .orElseThrow(() -> new TaskNotFoundException(eventId, taskId));
+
+        patchTask(task, patchTask);
+
+        taskRepository.save(task);
+    }
+
+    private void patchTask(Task toBePatched, Task patchTask) throws InvocationTargetException, IllegalAccessException {
+        utilsBean.copyProperties(toBePatched, patchTask);
     }
 }


### PR DESCRIPTION
This pull request introduces two key changes:

### Refactor task deletion method:

The `deleteTaskByEventIdAndTaskId` method has been refactored to use the more precise `findByEventIdAndId` method. This ensures that tasks are found by both `eventId` and `taskId`.

### Implement PATCH endpoint for task editing:

- A handler for PATCH requests has been added, which accepts changes in the form of `Map<String, Object>`.
- The changes provided in the patch are parsed and applied to the existing task. The `IgnoreNullBeanUtilsBean` is used to copy only non-null values, preserving the existing data of the task.